### PR TITLE
Insta example

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,4 +3,8 @@ class PagesController < ApplicationController
 
   def home
   end
+
+  def foo
+    @result = InstaExample.followers_elon
+  end
 end

--- a/app/services/insta_example.rb
+++ b/app/services/insta_example.rb
@@ -1,0 +1,29 @@
+class InstaExample
+  def self.followers_elon
+    # Requests from server doesn't need to accept a cookie consent
+
+    # Prepare selenium
+    Selenium::WebDriver::Chrome::Service.driver_path = ENV['CHROMEDRIVER_PATH']
+    driver = Selenium::WebDriver.for :chrome
+
+    # 1. Sign in to create session cookie
+    driver.navigate.to "https://www.instagram.com/accounts/login"
+    sleep 5
+    # fill in inputs (email/mdp)
+    inputs = driver.find_elements(:css, '._2hvTZ.pexuQ.zyHYP')
+    inputs[0].send_keys(ENV['INSTA_ID'])
+    inputs[1].send_keys(ENV['INSTA_MDP'])
+    # submit form
+    sleep 2
+    driver.find_elements(:css, '.sqdOP.L3NKy.y3zKF').last.click
+
+    sleep 4
+    # 2. Navigate to page we want to scrap
+    driver.navigate.to "https://www.instagram.com/elonmusk"
+    # for example followers count
+    followers = driver.find_element(:css, '.Y8-fY a span').attribute('innerHTML')
+
+    puts "==================================="
+    puts "Elon Musk has #{followers} followers"
+  end
+end

--- a/app/services/insta_example.rb
+++ b/app/services/insta_example.rb
@@ -4,26 +4,46 @@ class InstaExample
 
     # Prepare selenium
     Selenium::WebDriver::Chrome::Service.driver_path = ENV['CHROMEDRIVER_PATH']
-    driver = Selenium::WebDriver.for :chrome
+    caps = Selenium::WebDriver::Remote::Capabilities.new
+    caps["screen_resolution"] = "1024x768"
 
-    # 1. Sign in to create session cookie
-    driver.navigate.to "https://www.instagram.com/accounts/login"
-    sleep 5
-    # fill in inputs (email/mdp)
-    inputs = driver.find_elements(:css, '._2hvTZ.pexuQ.zyHYP')
-    inputs[0].send_keys(ENV['INSTA_ID'])
-    inputs[1].send_keys(ENV['INSTA_MDP'])
-    # submit form
-    sleep 2
-    driver.find_elements(:css, '.sqdOP.L3NKy.y3zKF').last.click
+    driver = Selenium::WebDriver.for(:chrome, desired_capabilities: caps)
 
-    sleep 4
-    # 2. Navigate to page we want to scrap
-    driver.navigate.to "https://www.instagram.com/elonmusk"
-    # for example followers count
-    followers = driver.find_element(:css, '.Y8-fY a span').attribute('innerHTML')
+    begin
+      # 1. Sign in to create session cookie
+      driver.navigate.to "https://www.instagram.com/accounts/login"
+      sleep 5
+      # fill in inputs (email/mdp)
+      inputs = driver.find_elements(:css, '._2hvTZ.pexuQ.zyHYP')
+      inputs[0].send_keys(ENV['INSTA_ID'])
+      inputs[1].send_keys(ENV['INSTA_MDP'])
+      # submit form
+      sleep 2
+      driver.find_elements(:css, '.sqdOP.L3NKy.y3zKF').last.click
 
-    puts "==================================="
-    puts "Elon Musk has #{followers} followers"
+      sleep 4
+      # 2. Navigate to page we want to scrap
+      driver.navigate.to "https://www.instagram.com/elonmusk"
+      # for example followers count
+      followers = driver.find_element(:css, '.Y8-fY a span').attribute('innerHTML')
+
+    # In case of exception, rescue it
+    rescue StandardError => e
+      # Take a screenshot that will be visible with www.clickandstalk.com/test.png
+      driver.save_screenshot("#{Rails.root}/public/test.png")
+
+      # Save HTML file that lead to error, available at www.clickandstalk.com/test.html
+      html = driver.find_element(:css, 'html').attribute('innerHTML')
+      File.open("#{Rails.root}/public/test.html", 'wb') { |file| file.write(html) }
+
+      # Note : Screenshot and html file won't be available many time, cause heroku
+      # destroys new created files that are not coming from git commits on every
+      # restart (at least one time per day)
+
+      # Return HTML
+      html
+    end
+
+    followers
   end
 end

--- a/app/views/pages/foo.html.erb
+++ b/app/views/pages/foo.html.erb
@@ -1,0 +1,1 @@
+<%= @result.html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
   get 'user/instagram', to: 'users#instagram', as: :instagram
   get 'user/linkedin', to: 'users#linkedin', as: :linkedin
 
+  get '/foo', to: 'pages#foo'
+
   get 'dashboard', to: 'users#dashboard', as: :dashboard
 
   root to: 'pages#home'

--- a/lib/tasks/insta.rake
+++ b/lib/tasks/insta.rake
@@ -1,0 +1,26 @@
+namespace :insta do
+  task scrap_example: :environment do
+    Selenium::WebDriver::Chrome::Service.driver_path = ENV['CHROMEDRIVER_PATH']
+    driver = Selenium::WebDriver.for :chrome
+
+    # 1. Sign in to create session cookie
+    driver.navigate.to "https://www.instagram.com/accounts/login"
+    sleep 5
+    # fill in inputs (email/mdp)
+    inputs = driver.find_elements(:css, '._2hvTZ.pexuQ.zyHYP')
+    inputs[0].send_keys(ENV['INSTA_ID'])
+    inputs[1].send_keys(ENV['INSTA_MDP'])
+    # submit form
+    sleep 2
+    driver.find_elements(:css, '.sqdOP.L3NKy.y3zKF').last.click
+
+    sleep 4
+    # 2. Navigate to page we want to scrap
+    driver.navigate.to "https://www.instagram.com/elonmusk"
+    # for example followers count
+    followers = driver.find_element(:css, '.Y8-fY a span').attribute('innerHTML')
+
+    puts "==================================="
+    puts "Elon Musk has #{followers} followers"
+  end
+end


### PR DESCRIPTION
Bon, du coup 
- Y'a une tache rails, qu'on peut lancer avec `rails insta: scrap_example`
Elle marche mais pas tout le temps :/

- Du coup, pour mieux comprendre les erreurs, j'ai fait une route /foo, qui appelle un service (InstaExample), qui fait la même chose que la tache, sauf que quand une erreur se produit, je fait un screenshot de la page html d'insta, et aussi une sauvegarde du contenu HTML qu'insta nous a renvoyé, histoire de voir visuellement ce qu'on a.
Ces 2 fichier sont accessible (apres une erreur du coup) vers /test.png et /test.html

Donc en gros quand vous êtes connecté, vous pouvez aller sur /foo, et si y'a une erreur, aller voir le fichier html (mieux que le png pour le coup, car inspectable) sur /test.html

En gros ca marche, mais pas tout le temps, car insta nous grille..

Autre chose, y'a pas de cookie consent apparement quand on fait une requête du serveur heroku (il doit être en irlande je pense), du coup pas besoin de faire la 1ere étape.

Inspirez vous du côté "begin / rescue" pour gérer les erreurs, et si ca se produit pendant le demo, day, c'est pas grave, qqun peut relancer le scrap via une console qques minutes apres, faudra juste meubler un peu :p 
